### PR TITLE
Add removeAll(keepingCapacity:) method

### DIFF
--- a/Sources/OSet.swift
+++ b/Sources/OSet.swift
@@ -29,6 +29,14 @@ public struct OSet<E: Hashable & Comparable>: SetAlgebra, MutableCollection, Ran
     internal var a: [E]
     internal var s: Set<E>
 
+    /// Removes all members from the OSet.
+    ///
+    /// - Parameter keepingCapacity: If true, the OSet's buffer capacity is preserved; if false, the underlying buffer is released. The default is false.
+    public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
+        a.removeAll(keepingCapacity: keepCapacity)
+        s.removeAll(keepingCapacity: keepCapacity)
+    }
+
     // MARK: SetAlgebra
 
     public typealias Element = E

--- a/Tests/OSetTests/OSetTests.swift
+++ b/Tests/OSetTests/OSetTests.swift
@@ -23,6 +23,14 @@ import XCTest
 @testable import OSet
 
 class OSetTests: XCTestCase {
+    func testRemoveAll() {
+        var oset = OSet([1, 2, 3])
+        oset.removeAll()
+
+        XCTAssertEqual(oset.a, [])
+        XCTAssertEqual(oset.s, [])
+    }
+
     // MARK: SetAlgebra
 
     func testInit() {


### PR DESCRIPTION
I was using OSet to replace an unordered Set use case, and there were some places where we were using removeAll(keepingCapacity:), so I added an implementation of that method.

I explored conforming to RangeReplaceableCollection, but I think that might require a lot of manual implementations of that protocol's methods in order to be correct, instead of relying on replaceSubrange. As a result I didn't do that for this PR.