### PR TITLE
Add conditional Codable and Hashable conformance

### DIFF
--- a/Sources/OSet.swift
+++ b/Sources/OSet.swift
@@ -25,7 +25,7 @@ internal func copy<E>(_ oset: OSet<E>, op: (inout OSet<E>) -> Void) -> OSet<E> {
     return copy
 }
 
-public struct OSet<E: Hashable>: SetAlgebra, MutableCollection, RandomAccessCollection, RangeReplaceableCollection {
+public struct OSet<E: Hashable>: SetAlgebra, MutableCollection, RandomAccessCollection, RangeReplaceableCollection, Hashable {
     internal var a: [E]
     internal var s: Set<E>
 
@@ -299,12 +299,32 @@ public struct OSet<E: Hashable>: SetAlgebra, MutableCollection, RandomAccessColl
     }
 
     // MARK: - RangeReplaceableCollection
+    // MARK: Hashable
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(a)
+    }
+
+    // MARK: - Hashable
 }
 
 extension OSet where E: Comparable {
     /// Sorts the collection ascendingly, in place.
     public mutating func sort() {
         self.a.sort()
+    }
+}
+
+extension OSet: Codable where E: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let elements = try container.decode([E].self)
+        self.init(elements)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(a)
     }
 }
 

--- a/Tests/OSetTests/OSetTests.swift
+++ b/Tests/OSetTests/OSetTests.swift
@@ -497,6 +497,39 @@ class OSetTests: XCTestCase {
     }
 
     // MARK: - Subscript
+    // MARK: Codable
+
+    func testDecodable() throws {
+        struct Value: Decodable {
+            let set: OSet<Int>
+        }
+        let cases = [
+            ("{ \"set\": [1, 2, 3] }", [1, 2, 3]),
+            ("{ \"set\": [1, 1, 2, 3] }", [1, 2, 3]),
+        ]
+        try cases.forEach {
+            guard let jsonData = $0.data(using: .utf8) else { XCTFail("Expected valid JSON data"); return }
+            let value = try JSONDecoder().decode(Value.self, from: jsonData)
+            XCTAssertEqual(value.set.a, $1)
+            XCTAssertEqual(value.set.s, Set($1))
+        }
+    }
+
+    func testEncodable() throws {
+        struct Value: Encodable {
+            let set: OSet<Int>
+        }
+        let cases = [
+            (Value(set: [1, 2, 3]), "{\"set\":[1,2,3]}"),
+            (Value(set: [1, 1, 2, 3]), "{\"set\":[1,2,3]}"),
+        ]
+        try cases.forEach {
+            let jsonData = try JSONEncoder().encode($0)
+            XCTAssertEqual(String(data: jsonData, encoding: .utf8), $1)
+        }
+    }
+
+    // MARK: - Codable
 
     static var allTests = [
         ("testInit", testInit),


### PR DESCRIPTION
This adds:

- Hashable conformance based on the array of elements, which matches the implementation of `==`.
- conditional Codable conformance when the element type is Codable, which uses the array value.